### PR TITLE
Add responsive breakpoints for tablet and phone

### DIFF
--- a/src/components/asana-card/asana-card.module.css
+++ b/src/components/asana-card/asana-card.module.css
@@ -55,3 +55,19 @@
     text-align: center;
     font-style: italic;
 }
+
+@media (max-width: 640px) {
+    .card {
+        min-height: 120px;
+        padding: var(--space-2);
+    }
+
+    .iconCircle {
+        width: 52px;
+        height: 52px;
+    }
+
+    .title {
+        font-size: 0.78em;
+    }
+}

--- a/src/components/pages/training-page/training-page.module.css
+++ b/src/components/pages/training-page/training-page.module.css
@@ -98,3 +98,44 @@
         transform: translateX(0);
     }
 }
+
+@media (max-width: 1024px) {
+    .container {
+        grid-template-columns: repeat(3, 1fr);
+    }
+}
+
+@media (max-width: 640px) {
+    .main {
+        padding: var(--space-4);
+        row-gap: var(--space-5);
+    }
+
+    .header {
+        flex-wrap: wrap;
+    }
+
+    .headerTitle {
+        flex-basis: 100%;
+    }
+
+    .container {
+        grid-template-columns: repeat(2, 1fr);
+    }
+
+    .library {
+        padding: var(--space-3);
+    }
+
+    .asanasContainer {
+        grid-template-columns: repeat(auto-fill, minmax(96px, 1fr));
+        gap: var(--space-2);
+    }
+
+    .aiNotification {
+        top: 12px;
+        right: 12px;
+        left: 12px;
+        font-size: 13px;
+    }
+}

--- a/src/components/training-step/training-step.module.css
+++ b/src/components/training-step/training-step.module.css
@@ -40,3 +40,10 @@
     font-style: italic;
     user-select: none;
 }
+
+@media (max-width: 640px) {
+    .step {
+        min-height: 180px;
+        padding: var(--space-2);
+    }
+}


### PR DESCRIPTION
Training steps row collapses from 6 to 3 columns at <=1024px and to 2 columns at <=640px, since six tiles at phone widths were ~40px wide and unusable. Main padding shrinks, the header wraps so the title sits on its own row above the date input and Save button, and the asana library switches to a tighter 96px-min grid with smaller icon circles.