### PR TITLE
[Plan Mode] Fix mobile drag and drop with DragOverlay and proper sensors

### DIFF
--- a/src/components/asana-card/asana-card.module.css
+++ b/src/components/asana-card/asana-card.module.css
@@ -12,6 +12,8 @@
     box-shadow: var(--shadow-sm);
     box-sizing: border-box;
     cursor: grab;
+    touch-action: none;
+    user-select: none;
     transition: transform 0.12s, box-shadow 0.12s, border-color 0.12s;
 }
 

--- a/src/components/asana-card/asana-card.tsx
+++ b/src/components/asana-card/asana-card.tsx
@@ -3,17 +3,24 @@ import type { Asana } from '@/constants/asana.ts';
 import {useDraggable} from '@dnd-kit/core';
 import Image from 'next/image';
 
-export const AsanaCard = (asana: Asana) => {
-  const {attributes, listeners, setNodeRef, transform} = useDraggable({
+type AsanaCardProps = Asana & { overlay?: boolean };
+
+export const AsanaCard = ({ overlay, ...asana }: AsanaCardProps) => {
+  const {attributes, listeners, setNodeRef, isDragging} = useDraggable({
     id: `${asana.english_name}`,
+    disabled: overlay,
   });
 
-  const style = transform ? {
-    transform: `translate3d(${transform.x}px, ${transform.y}px, 0)`,
-  } : undefined;
+  const style = isDragging && !overlay ? { opacity: 0 } : undefined;
 
   return (
-        <article className={styles.card} ref={setNodeRef} style={style} {...listeners} {...attributes}>
+        <article
+          className={styles.card}
+          ref={overlay ? undefined : setNodeRef}
+          style={style}
+          {...(overlay ? {} : listeners)}
+          {...(overlay ? {} : attributes)}
+        >
           <div className={styles.iconCircle}>
             <Image
               src={asana.url_svg}

--- a/src/components/pages/training-page/training-page.tsx
+++ b/src/components/pages/training-page/training-page.tsx
@@ -6,7 +6,7 @@ import { Chat } from '@/components/chat/chat';
 import styles from './training-page.module.css';
 import { type Asana, ASANAS } from '@/constants/asana';
 import { STEPS } from '@/constants/steps';
-import { DndContext, DragEndEvent } from '@dnd-kit/core';
+import { DndContext, DragEndEvent, DragOverlay, DragStartEvent, MouseSensor, TouchSensor, useSensor, useSensors } from '@dnd-kit/core';
 import { type ChangeEvent, useCallback, useEffect, useState } from 'react';
 import type { TrainingSteps } from '@/models/training.model';
 import { getTrainings, saveTraining } from '@/services/training.service';
@@ -19,6 +19,12 @@ export const TrainingPage = ({trainingDate: propsTrainingDate}: TrainingPageProp
   const [trainingSteps, setTrainingSteps] = useState<TrainingSteps>({});
   const [trainingDate, setTrainingDate] = useState(propsTrainingDate || new Date());
   const [showAIAppliedNotification, setShowAIAppliedNotification] = useState(false);
+  const [activeDragId, setActiveDragId] = useState<string | null>(null);
+
+  const sensors = useSensors(
+    useSensor(MouseSensor, { activationConstraint: { distance: 8 } }),
+    useSensor(TouchSensor, { activationConstraint: { delay: 250, tolerance: 5 } }),
+  );
 
   const setTrainingFromTheDate = useCallback((date: Date) => {
     const storedTrainings = getTrainings(formatDate(date));
@@ -33,7 +39,12 @@ export const TrainingPage = ({trainingDate: propsTrainingDate}: TrainingPageProp
     }
   }, [propsTrainingDate, setTrainingFromTheDate]);
 
+  function handleDragStart({ active }: DragStartEvent) {
+    setActiveDragId(active.id as string);
+  }
+
   function handleDragEnd(event: DragEndEvent) {
+    setActiveDragId(null);
     const { active: draggingAsanaCard, over: overTrainingStep } = event;
 
     if (overTrainingStep) {
@@ -95,7 +106,7 @@ export const TrainingPage = ({trainingDate: propsTrainingDate}: TrainingPageProp
   }
 
   return (
-    <DndContext  onDragEnd={handleDragEnd}>
+    <DndContext sensors={sensors} onDragStart={handleDragStart} onDragEnd={handleDragEnd}>
       <main className={styles.main}>
 
         <header className={styles.header}>
@@ -126,8 +137,14 @@ export const TrainingPage = ({trainingDate: propsTrainingDate}: TrainingPageProp
           ✨ AI yoga sequence applied successfully! Check your training steps.
         </div>
       )}
-      
+
       <Chat onTrainingPlanGenerated={handleAITrainingPlan} />
+
+      <DragOverlay>
+        {activeDragId ? (
+          <AsanaCard {...ASANAS.find(a => a.english_name === activeDragId)!} overlay />
+        ) : null}
+      </DragOverlay>
     </DndContext>
   )
 }


### PR DESCRIPTION
- Add TouchSensor (250ms delay) + MouseSensor (8px distance) so touch users can scroll the page normally and press-hold to drag
- Add DragOverlay so a floating card follows the finger instead of transforming the source element in-place (prevents layout jank on mobile)
- Set source card opacity:0 while dragging to create a "lifted" effect
- Add touch-action:none and user-select:none to card CSS to prevent browser from intercepting touch events before dnd-kit can handle them