### PR TITLE
[OpenSpec] feat: migrate training storage to IndexedDB with OpenSpec setup

### DIFF
--- a/.claude/commands/opsx/apply.md
+++ b/.claude/commands/opsx/apply.md
@@ -1,0 +1,152 @@
+---
+name: "OPSX: Apply"
+description: Implement tasks from an OpenSpec change (Experimental)
+category: Workflow
+tags: [workflow, artifacts, experimental]
+---
+
+Implement tasks from an OpenSpec change.
+
+**Input**: Optionally specify a change name (e.g., `/opsx:apply add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and use the **AskUserQuestion tool** to let the user select
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:apply <other>`).
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
+
+3. **Get apply instructions**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns:
+   - `contextFiles`: artifact ID -> array of concrete file paths (varies by schema)
+   - Progress (total, complete, remaining)
+   - Task list with status
+   - Dynamic instruction based on current state
+
+   **Handle states:**
+   - If `state: "blocked"` (missing artifacts): show message, suggest using `/opsx:continue`
+   - If `state: "all_done"`: congratulate, suggest archive
+   - Otherwise: proceed to implementation
+
+4. **Read context files**
+
+   Read every file path listed under `contextFiles` from the apply instructions output.
+   The files depend on the schema being used:
+   - **spec-driven**: proposal, specs, design, tasks
+   - Other schemas: follow the contextFiles from CLI output
+
+5. **Show current progress**
+
+   Display:
+   - Schema being used
+   - Progress: "N/M tasks complete"
+   - Remaining tasks overview
+   - Dynamic instruction from CLI
+
+6. **Implement tasks (loop until done or blocked)**
+
+   For each pending task:
+   - Show which task is being worked on
+   - Make the code changes required
+   - Keep changes minimal and focused
+   - Mark task complete in the tasks file: `- [ ]` → `- [x]`
+   - Continue to next task
+
+   **Pause if:**
+   - Task is unclear → ask for clarification
+   - Implementation reveals a design issue → suggest updating artifacts
+   - Error or blocker encountered → report and wait for guidance
+   - User interrupts
+
+7. **On completion or pause, show status**
+
+   Display:
+   - Tasks completed this session
+   - Overall progress: "N/M tasks complete"
+   - If all done: suggest archive
+   - If paused: explain why and wait for guidance
+
+**Output During Implementation**
+
+```
+## Implementing: <change-name> (schema: <schema-name>)
+
+Working on task 3/7: <task description>
+[...implementation happening...]
+✓ Task complete
+
+Working on task 4/7: <task description>
+[...implementation happening...]
+✓ Task complete
+```
+
+**Output On Completion**
+
+```
+## Implementation Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 7/7 tasks complete ✓
+
+### Completed This Session
+- [x] Task 1
+- [x] Task 2
+...
+
+All tasks complete! You can archive this change with `/opsx:archive`.
+```
+
+**Output On Pause (Issue Encountered)**
+
+```
+## Implementation Paused
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 4/7 tasks complete
+
+### Issue Encountered
+<description of the issue>
+
+**Options:**
+1. <option 1>
+2. <option 2>
+3. Other approach
+
+What would you like to do?
+```
+
+**Guardrails**
+- Keep going through tasks until done or blocked
+- Always read context files before starting (from the apply instructions output)
+- If task is ambiguous, pause and ask before implementing
+- If implementation reveals issues, pause and suggest artifact updates
+- Keep code changes minimal and scoped to each task
+- Update task checkbox immediately after completing each task
+- Pause on errors, blockers, or unclear requirements - don't guess
+- Use contextFiles from CLI output, don't assume specific file names
+
+**Fluid Workflow Integration**
+
+This skill supports the "actions on a change" model:
+
+- **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
+- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly

--- a/.claude/commands/opsx/archive.md
+++ b/.claude/commands/opsx/archive.md
@@ -1,0 +1,157 @@
+---
+name: "OPSX: Archive"
+description: Archive a completed change in the experimental workflow
+category: Workflow
+tags: [workflow, archive, experimental]
+---
+
+Archive a completed change in the experimental workflow.
+
+**Input**: Optionally specify a change name after `/opsx:archive` (e.g., `/opsx:archive add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show only active changes (not already archived).
+   Include the schema used for each change if available.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check artifact completion status**
+
+   Run `openspec status --change "<name>" --json` to check artifact completion.
+
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used
+   - `artifacts`: List of artifacts with their status (`done` or other)
+
+   **If any artifacts are not `done`:**
+   - Display warning listing incomplete artifacts
+   - Prompt user for confirmation to continue
+   - Proceed if user confirms
+
+3. **Check task completion status**
+
+   Read the tasks file (typically `tasks.md`) to check for incomplete tasks.
+
+   Count tasks marked with `- [ ]` (incomplete) vs `- [x]` (complete).
+
+   **If incomplete tasks found:**
+   - Display warning showing count of incomplete tasks
+   - Prompt user for confirmation to continue
+   - Proceed if user confirms
+
+   **If no tasks file exists:** Proceed without task-related warning.
+
+4. **Assess delta spec sync state**
+
+   Check for delta specs at `openspec/changes/<name>/specs/`. If none exist, proceed without sync prompt.
+
+   **If delta specs exist:**
+   - Compare each delta spec with its corresponding main spec at `openspec/specs/<capability>/spec.md`
+   - Determine what changes would be applied (adds, modifications, removals, renames)
+   - Show a combined summary before prompting
+
+   **Prompt options:**
+   - If changes needed: "Sync now (recommended)", "Archive without syncing"
+   - If already synced: "Archive now", "Sync anyway", "Cancel"
+
+   If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
+
+5. **Perform the archive**
+
+   Create the archive directory if it doesn't exist:
+   ```bash
+   mkdir -p openspec/changes/archive
+   ```
+
+   Generate target name using current date: `YYYY-MM-DD-<change-name>`
+
+   **Check if target already exists:**
+   - If yes: Fail with error, suggest renaming existing archive or using different date
+   - If no: Move the change directory to archive
+
+   ```bash
+   mv openspec/changes/<name> openspec/changes/archive/YYYY-MM-DD-<name>
+   ```
+
+6. **Display summary**
+
+   Show archive completion summary including:
+   - Change name
+   - Schema that was used
+   - Archive location
+   - Spec sync status (synced / sync skipped / no delta specs)
+   - Note about any warnings (incomplete artifacts/tasks)
+
+**Output On Success**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** ✓ Synced to main specs
+
+All artifacts complete. All tasks complete.
+```
+
+**Output On Success (No Delta Specs)**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** No delta specs
+
+All artifacts complete. All tasks complete.
+```
+
+**Output On Success With Warnings**
+
+```
+## Archive Complete (with warnings)
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** Sync skipped (user chose to skip)
+
+**Warnings:**
+- Archived with 2 incomplete artifacts
+- Archived with 3 incomplete tasks
+- Delta spec sync was skipped (user chose to skip)
+
+Review the archive if this was not intentional.
+```
+
+**Output On Error (Archive Exists)**
+
+```
+## Archive Failed
+
+**Change:** <change-name>
+**Target:** openspec/changes/archive/YYYY-MM-DD-<name>/
+
+Target archive directory already exists.
+
+**Options:**
+1. Rename the existing archive
+2. Delete the existing archive if it's a duplicate
+3. Wait until a different date to archive
+```
+
+**Guardrails**
+- Always prompt for change selection if not provided
+- Use artifact graph (openspec status --json) for completion checking
+- Don't block archive on warnings - just inform and confirm
+- Preserve .openspec.yaml when moving to archive (it moves with the directory)
+- Show clear summary of what happened
+- If sync is requested, use the Skill tool to invoke `openspec-sync-specs` (agent-driven)
+- If delta specs exist, always run the sync assessment and show the combined summary before prompting

--- a/.claude/commands/opsx/explore.md
+++ b/.claude/commands/opsx/explore.md
@@ -1,0 +1,173 @@
+---
+name: "OPSX: Explore"
+description: "Enter explore mode - think through ideas, investigate problems, clarify requirements"
+category: Workflow
+tags: [workflow, explore, experimental, thinking]
+---
+
+Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
+
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
+
+**This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
+
+**Input**: The argument after `/opsx:explore` is whatever the user wants to think about. Could be:
+- A vague idea: "real-time collaboration"
+- A specific problem: "the auth system is getting unwieldy"
+- A change name: "add-dark-mode" (to explore in context of that change)
+- A comparison: "postgres vs sqlite for this"
+- Nothing (just enter explore mode)
+
+---
+
+## The Stance
+
+- **Curious, not prescriptive** - Ask questions that emerge naturally, don't follow a script
+- **Open threads, not interrogations** - Surface multiple interesting directions and let the user follow what resonates. Don't funnel them through a single path of questions.
+- **Visual** - Use ASCII diagrams liberally when they'd help clarify thinking
+- **Adaptive** - Follow interesting threads, pivot when new information emerges
+- **Patient** - Don't rush to conclusions, let the shape of the problem emerge
+- **Grounded** - Explore the actual codebase when relevant, don't just theorize
+
+---
+
+## What You Might Do
+
+Depending on what the user brings, you might:
+
+**Explore the problem space**
+- Ask clarifying questions that emerge from what they said
+- Challenge assumptions
+- Reframe the problem
+- Find analogies
+
+**Investigate the codebase**
+- Map existing architecture relevant to the discussion
+- Find integration points
+- Identify patterns already in use
+- Surface hidden complexity
+
+**Compare options**
+- Brainstorm multiple approaches
+- Build comparison tables
+- Sketch tradeoffs
+- Recommend a path (if asked)
+
+**Visualize**
+```
+┌─────────────────────────────────────────┐
+│     Use ASCII diagrams liberally        │
+├─────────────────────────────────────────┤
+│                                         │
+│      ┌────────┐         ┌────────┐      │
+│      │ State  │────────▶│ State  │      │
+│      │   A    │         │   B    │      │
+│      └────────┘         └────────┘      │
+│                                         │
+│   System diagrams, state machines,      │
+│   data flows, architecture sketches,    │
+│   dependency graphs, comparison tables  │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+**Surface risks and unknowns**
+- Identify what could go wrong
+- Find gaps in understanding
+- Suggest spikes or investigations
+
+---
+
+## OpenSpec Awareness
+
+You have full context of the OpenSpec system. Use it naturally, don't force it.
+
+### Check for context
+
+At the start, quickly check what exists:
+```bash
+openspec list --json
+```
+
+This tells you:
+- If there are active changes
+- Their names, schemas, and status
+- What the user might be working on
+
+If the user mentioned a specific change name, read its artifacts for context.
+
+### When no change exists
+
+Think freely. When insights crystallize, you might offer:
+
+- "This feels solid enough to start a change. Want me to create a proposal?"
+- Or keep exploring - no pressure to formalize
+
+### When a change exists
+
+If the user mentions a change or you detect one is relevant:
+
+1. **Read existing artifacts for context**
+   - `openspec/changes/<name>/proposal.md`
+   - `openspec/changes/<name>/design.md`
+   - `openspec/changes/<name>/tasks.md`
+   - etc.
+
+2. **Reference them naturally in conversation**
+   - "Your design mentions using Redis, but we just realized SQLite fits better..."
+   - "The proposal scopes this to premium users, but we're now thinking everyone..."
+
+3. **Offer to capture when decisions are made**
+
+    | Insight Type               | Where to Capture               |
+    |----------------------------|--------------------------------|
+    | New requirement discovered | `specs/<capability>/spec.md` |
+    | Requirement changed        | `specs/<capability>/spec.md` |
+    | Design decision made       | `design.md`                  |
+    | Scope changed              | `proposal.md`                |
+    | New work identified        | `tasks.md`                   |
+    | Assumption invalidated     | Relevant artifact              |
+
+   Example offers:
+   - "That's a design decision. Capture it in design.md?"
+   - "This is a new requirement. Add it to specs?"
+   - "This changes scope. Update the proposal?"
+
+4. **The user decides** - Offer and move on. Don't pressure. Don't auto-capture.
+
+---
+
+## What You Don't Have To Do
+
+- Follow a script
+- Ask the same questions every time
+- Produce a specific artifact
+- Reach a conclusion
+- Stay on topic if a tangent is valuable
+- Be brief (this is thinking time)
+
+---
+
+## Ending Discovery
+
+There's no required ending. Discovery might:
+
+- **Flow into a proposal**: "Ready to start? I can create a change proposal."
+- **Result in artifact updates**: "Updated design.md with these decisions"
+- **Just provide clarity**: User has what they need, moves on
+- **Continue later**: "We can pick this up anytime"
+
+When things crystallize, you might offer a summary - but it's optional. Sometimes the thinking IS the value.
+
+---
+
+## Guardrails
+
+- **Don't implement** - Never write code or implement features. Creating OpenSpec artifacts is fine, writing application code is not.
+- **Don't fake understanding** - If something is unclear, dig deeper
+- **Don't rush** - Discovery is thinking time, not task time
+- **Don't force structure** - Let patterns emerge naturally
+- **Don't auto-capture** - Offer to save insights, don't just do it
+- **Do visualize** - A good diagram is worth many paragraphs
+- **Do explore the codebase** - Ground discussions in reality
+- **Do question assumptions** - Including the user's and your own

--- a/.claude/commands/opsx/new.md
+++ b/.claude/commands/opsx/new.md
@@ -1,0 +1,69 @@
+---
+name: "OPSX: New"
+description: Start a new change using the experimental artifact workflow (OPSX)
+category: Workflow
+tags: [workflow, artifacts, experimental]
+---
+
+Start a new change using the experimental artifact-driven approach.
+
+**Input**: The argument after `/opsx:new` is the change name (kebab-case), OR a description of what the user wants to build.
+
+**Steps**
+
+1. **If no input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Determine the workflow schema**
+
+   Use the default schema (omit `--schema`) unless the user explicitly requests a different workflow.
+
+   **Use a different schema only if the user mentions:**
+   - A specific schema name → use `--schema <name>`
+   - "show workflows" or "what workflows" → run `openspec schemas --json` and let them choose
+
+   **Otherwise**: Omit `--schema` to use the default.
+
+3. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   Add `--schema <name>` only if the user requested a specific workflow.
+   This creates a scaffolded change at `openspec/changes/<name>/` with the selected schema.
+
+4. **Show the artifact status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+   This shows which artifacts need to be created and which are ready (dependencies satisfied).
+
+5. **Get instructions for the first artifact**
+   The first artifact depends on the schema. Check the status output to find the first artifact with status "ready".
+   ```bash
+   openspec instructions <first-artifact-id> --change "<name>"
+   ```
+   This outputs the template and context for creating the first artifact.
+
+6. **STOP and wait for user direction**
+
+**Output**
+
+After completing the steps, summarize:
+- Change name and location
+- Schema/workflow being used and its artifact sequence
+- Current status (0/N artifacts complete)
+- The template for the first artifact
+- Prompt: "Ready to create the first artifact? Run `/opsx:continue` or just describe what this change is about and I'll draft it."
+
+**Guardrails**
+- Do NOT create any artifacts yet - just show the instructions
+- Do NOT advance beyond showing the first artifact template
+- If the name is invalid (not kebab-case), ask for a valid name
+- If a change with that name already exists, suggest using `/opsx:continue` instead
+- Pass --schema if using a non-default workflow

--- a/.claude/commands/opsx/propose.md
+++ b/.claude/commands/opsx/propose.md
@@ -1,0 +1,106 @@
+---
+name: "OPSX: Propose"
+description: Propose a new change - create it and generate all artifacts in one step
+category: Workflow
+tags: [workflow, artifacts, experimental]
+---
+
+Propose a new change - create the change and generate all artifacts in one step.
+
+I'll create a change with artifacts:
+- proposal.md (what & why)
+- design.md (how)
+- tasks.md (implementation steps)
+
+When ready to implement, run /opsx:apply
+
+---
+
+**Input**: The argument after `/opsx:propose` is the change name (kebab-case), OR a description of what the user wants to build.
+
+**Steps**
+
+1. **If no input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change at `openspec/changes/<name>/` with `.openspec.yaml`.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts with their status and dependencies
+
+4. **Create artifacts in sequence until apply-ready**
+
+   Use the **TodoWrite tool** to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `outputPath`: Where to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context
+      - Create the artifact file using `template` as the structure
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "Created <artifact-id>"
+
+   b. **Continue until all `applyRequires` artifacts are complete**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
+      - Stop when all `applyRequires` artifacts are done
+
+   c. **If an artifact requires user input** (unclear context):
+      - Use **AskUserQuestion tool** to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions
+- What's ready: "All artifacts created! Ready for implementation."
+- Prompt: "Run `/opsx:apply` to start implementing."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
+- Always read dependency artifacts before creating a new one
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, ask if user wants to continue it or create a new one
+- Verify each artifact file exists after writing before proceeding to next

--- a/.claude/skills/openspec-apply-change/SKILL.md
+++ b/.claude/skills/openspec-apply-change/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: openspec-apply-change
+description: Implement tasks from an OpenSpec change. Use when the user wants to start implementing, continue implementation, or work through tasks.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.1"
+---
+
+Implement tasks from an OpenSpec change.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and use the **AskUserQuestion tool** to let the user select
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:apply <other>`).
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
+
+3. **Get apply instructions**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns:
+   - `contextFiles`: artifact ID -> array of concrete file paths (varies by schema - could be proposal/specs/design/tasks or spec/tests/implementation/docs)
+   - Progress (total, complete, remaining)
+   - Task list with status
+   - Dynamic instruction based on current state
+
+   **Handle states:**
+   - If `state: "blocked"` (missing artifacts): show message, suggest using openspec-continue-change
+   - If `state: "all_done"`: congratulate, suggest archive
+   - Otherwise: proceed to implementation
+
+4. **Read context files**
+
+   Read every file path listed under `contextFiles` from the apply instructions output.
+   The files depend on the schema being used:
+   - **spec-driven**: proposal, specs, design, tasks
+   - Other schemas: follow the contextFiles from CLI output
+
+5. **Show current progress**
+
+   Display:
+   - Schema being used
+   - Progress: "N/M tasks complete"
+   - Remaining tasks overview
+   - Dynamic instruction from CLI
+
+6. **Implement tasks (loop until done or blocked)**
+
+   For each pending task:
+   - Show which task is being worked on
+   - Make the code changes required
+   - Keep changes minimal and focused
+   - Mark task complete in the tasks file: `- [ ]` → `- [x]`
+   - Continue to next task
+
+   **Pause if:**
+   - Task is unclear → ask for clarification
+   - Implementation reveals a design issue → suggest updating artifacts
+   - Error or blocker encountered → report and wait for guidance
+   - User interrupts
+
+7. **On completion or pause, show status**
+
+   Display:
+   - Tasks completed this session
+   - Overall progress: "N/M tasks complete"
+   - If all done: suggest archive
+   - If paused: explain why and wait for guidance
+
+**Output During Implementation**
+
+```
+## Implementing: <change-name> (schema: <schema-name>)
+
+Working on task 3/7: <task description>
+[...implementation happening...]
+✓ Task complete
+
+Working on task 4/7: <task description>
+[...implementation happening...]
+✓ Task complete
+```
+
+**Output On Completion**
+
+```
+## Implementation Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 7/7 tasks complete ✓
+
+### Completed This Session
+- [x] Task 1
+- [x] Task 2
+...
+
+All tasks complete! Ready to archive this change.
+```
+
+**Output On Pause (Issue Encountered)**
+
+```
+## Implementation Paused
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 4/7 tasks complete
+
+### Issue Encountered
+<description of the issue>
+
+**Options:**
+1. <option 1>
+2. <option 2>
+3. Other approach
+
+What would you like to do?
+```
+
+**Guardrails**
+- Keep going through tasks until done or blocked
+- Always read context files before starting (from the apply instructions output)
+- If task is ambiguous, pause and ask before implementing
+- If implementation reveals issues, pause and suggest artifact updates
+- Keep code changes minimal and scoped to each task
+- Update task checkbox immediately after completing each task
+- Pause on errors, blockers, or unclear requirements - don't guess
+- Use contextFiles from CLI output, don't assume specific file names
+
+**Fluid Workflow Integration**
+
+This skill supports the "actions on a change" model:
+
+- **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
+- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly

--- a/.claude/skills/openspec-archive-change/SKILL.md
+++ b/.claude/skills/openspec-archive-change/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: openspec-archive-change
+description: Archive a completed change in the experimental workflow. Use when the user wants to finalize and archive a change after implementation is complete.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.1"
+---
+
+Archive a completed change in the experimental workflow.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show only active changes (not already archived).
+   Include the schema used for each change if available.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check artifact completion status**
+
+   Run `openspec status --change "<name>" --json` to check artifact completion.
+
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used
+   - `artifacts`: List of artifacts with their status (`done` or other)
+
+   **If any artifacts are not `done`:**
+   - Display warning listing incomplete artifacts
+   - Use **AskUserQuestion tool** to confirm user wants to proceed
+   - Proceed if user confirms
+
+3. **Check task completion status**
+
+   Read the tasks file (typically `tasks.md`) to check for incomplete tasks.
+
+   Count tasks marked with `- [ ]` (incomplete) vs `- [x]` (complete).
+
+   **If incomplete tasks found:**
+   - Display warning showing count of incomplete tasks
+   - Use **AskUserQuestion tool** to confirm user wants to proceed
+   - Proceed if user confirms
+
+   **If no tasks file exists:** Proceed without task-related warning.
+
+4. **Assess delta spec sync state**
+
+   Check for delta specs at `openspec/changes/<name>/specs/`. If none exist, proceed without sync prompt.
+
+   **If delta specs exist:**
+   - Compare each delta spec with its corresponding main spec at `openspec/specs/<capability>/spec.md`
+   - Determine what changes would be applied (adds, modifications, removals, renames)
+   - Show a combined summary before prompting
+
+   **Prompt options:**
+   - If changes needed: "Sync now (recommended)", "Archive without syncing"
+   - If already synced: "Archive now", "Sync anyway", "Cancel"
+
+   If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
+
+5. **Perform the archive**
+
+   Create the archive directory if it doesn't exist:
+   ```bash
+   mkdir -p openspec/changes/archive
+   ```
+
+   Generate target name using current date: `YYYY-MM-DD-<change-name>`
+
+   **Check if target already exists:**
+   - If yes: Fail with error, suggest renaming existing archive or using different date
+   - If no: Move the change directory to archive
+
+   ```bash
+   mv openspec/changes/<name> openspec/changes/archive/YYYY-MM-DD-<name>
+   ```
+
+6. **Display summary**
+
+   Show archive completion summary including:
+   - Change name
+   - Schema that was used
+   - Archive location
+   - Whether specs were synced (if applicable)
+   - Note about any warnings (incomplete artifacts/tasks)
+
+**Output On Success**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** ✓ Synced to main specs (or "No delta specs" or "Sync skipped")
+
+All artifacts complete. All tasks complete.
+```
+
+**Guardrails**
+- Always prompt for change selection if not provided
+- Use artifact graph (openspec status --json) for completion checking
+- Don't block archive on warnings - just inform and confirm
+- Preserve .openspec.yaml when moving to archive (it moves with the directory)
+- Show clear summary of what happened
+- If sync is requested, use openspec-sync-specs approach (agent-driven)
+- If delta specs exist, always run the sync assessment and show the combined summary before prompting

--- a/.claude/skills/openspec-explore/SKILL.md
+++ b/.claude/skills/openspec-explore/SKILL.md
@@ -1,0 +1,288 @@
+---
+name: openspec-explore
+description: Enter explore mode - a thinking partner for exploring ideas, investigating problems, and clarifying requirements. Use when the user wants to think through something before or during a change.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.1"
+---
+
+Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
+
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
+
+**This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
+
+---
+
+## The Stance
+
+- **Curious, not prescriptive** - Ask questions that emerge naturally, don't follow a script
+- **Open threads, not interrogations** - Surface multiple interesting directions and let the user follow what resonates. Don't funnel them through a single path of questions.
+- **Visual** - Use ASCII diagrams liberally when they'd help clarify thinking
+- **Adaptive** - Follow interesting threads, pivot when new information emerges
+- **Patient** - Don't rush to conclusions, let the shape of the problem emerge
+- **Grounded** - Explore the actual codebase when relevant, don't just theorize
+
+---
+
+## What You Might Do
+
+Depending on what the user brings, you might:
+
+**Explore the problem space**
+- Ask clarifying questions that emerge from what they said
+- Challenge assumptions
+- Reframe the problem
+- Find analogies
+
+**Investigate the codebase**
+- Map existing architecture relevant to the discussion
+- Find integration points
+- Identify patterns already in use
+- Surface hidden complexity
+
+**Compare options**
+- Brainstorm multiple approaches
+- Build comparison tables
+- Sketch tradeoffs
+- Recommend a path (if asked)
+
+**Visualize**
+```
+┌─────────────────────────────────────────┐
+│     Use ASCII diagrams liberally        │
+├─────────────────────────────────────────┤
+│                                         │
+│      ┌────────┐         ┌────────┐      │
+│      │ State  │────────▶│ State  │      │
+│      │   A    │         │   B    │      │
+│      └────────┘         └────────┘      │
+│                                         │
+│   System diagrams, state machines,      │
+│   data flows, architecture sketches,    │
+│   dependency graphs, comparison tables  │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+**Surface risks and unknowns**
+- Identify what could go wrong
+- Find gaps in understanding
+- Suggest spikes or investigations
+
+---
+
+## OpenSpec Awareness
+
+You have full context of the OpenSpec system. Use it naturally, don't force it.
+
+### Check for context
+
+At the start, quickly check what exists:
+```bash
+openspec list --json
+```
+
+This tells you:
+- If there are active changes
+- Their names, schemas, and status
+- What the user might be working on
+
+### When no change exists
+
+Think freely. When insights crystallize, you might offer:
+
+- "This feels solid enough to start a change. Want me to create a proposal?"
+- Or keep exploring - no pressure to formalize
+
+### When a change exists
+
+If the user mentions a change or you detect one is relevant:
+
+1. **Read existing artifacts for context**
+   - `openspec/changes/<name>/proposal.md`
+   - `openspec/changes/<name>/design.md`
+   - `openspec/changes/<name>/tasks.md`
+   - etc.
+
+2. **Reference them naturally in conversation**
+   - "Your design mentions using Redis, but we just realized SQLite fits better..."
+   - "The proposal scopes this to premium users, but we're now thinking everyone..."
+
+3. **Offer to capture when decisions are made**
+
+    | Insight Type               | Where to Capture               |
+    |----------------------------|--------------------------------|
+    | New requirement discovered | `specs/<capability>/spec.md` |
+    | Requirement changed        | `specs/<capability>/spec.md` |
+    | Design decision made       | `design.md`                  |
+    | Scope changed              | `proposal.md`                |
+    | New work identified        | `tasks.md`                   |
+    | Assumption invalidated     | Relevant artifact              |
+
+   Example offers:
+   - "That's a design decision. Capture it in design.md?"
+   - "This is a new requirement. Add it to specs?"
+   - "This changes scope. Update the proposal?"
+
+4. **The user decides** - Offer and move on. Don't pressure. Don't auto-capture.
+
+---
+
+## What You Don't Have To Do
+
+- Follow a script
+- Ask the same questions every time
+- Produce a specific artifact
+- Reach a conclusion
+- Stay on topic if a tangent is valuable
+- Be brief (this is thinking time)
+
+---
+
+## Handling Different Entry Points
+
+**User brings a vague idea:**
+```
+User: I'm thinking about adding real-time collaboration
+
+You: Real-time collab is a big space. Let me think about this...
+
+      COLLABORATION SPECTRUM
+      ════════════════════════════════════════════
+
+      Awareness          Coordination         Sync
+          │                   │                 │
+          ▼                   ▼                 ▼
+      ┌────────┐         ┌────────┐        ┌────────┐
+      │Presence│         │Cursors │        │  CRDT  │
+      │  "3    │         │ Multi  │        │Conflict│
+      │online" │         │ select │        │  free  │
+      └────────┘         └────────┘        └────────┘
+          │                   │                 │
+       trivial            moderate           complex
+
+      Where's your head at?
+```
+
+**User brings a specific problem:**
+```
+User: The auth system is a mess
+
+You: [reads codebase]
+
+     ┌─────────────────────────────────────────────┐
+     │              CURRENT AUTH FLOW              │
+     └─────────────────────────────────────────────┘
+                        │
+          ┌─────────────┼─────────────┐
+          ▼             ▼             ▼
+     ┌─────────┐  ┌─────────┐  ┌─────────┐
+     │ Google  │  │  GitHub │  │  Email  │
+     │  OAuth  │  │  OAuth  │  │  Magic  │
+     └────┬────┘  └────┬────┘  └────┬────┘
+          │             │             │
+          └─────────────┼─────────────┘
+                        ▼
+                  ┌───────────┐
+                  │  Session  │
+                  └─────┬─────┘
+                        │
+                        ▼
+                  ┌───────────┐
+                  │   Perms   │
+                  └───────────┘
+
+     I see three tangles. Which one's burning?
+```
+
+**User is stuck mid-implementation:**
+```
+User: /opsx:explore add-auth-system
+      The OAuth integration is more complex than expected
+
+You: [reads change artifacts]
+
+     You're on task 4: "Implement OAuth flow"
+
+     Let me trace what's involved...
+
+     [draws diagram, explores options, suggests paths]
+
+     Want to update the design to reflect this?
+     Or add a spike task to investigate?
+```
+
+**User wants to compare options:**
+```
+User: Should we use Postgres or SQLite?
+
+You: Generic answer is boring. What's the context?
+
+User: A CLI tool that tracks local dev environments
+
+You: That changes everything.
+
+     ┌─────────────────────────────────────────────────┐
+     │          CLI TOOL DATA STORAGE                  │
+     └─────────────────────────────────────────────────┘
+
+     Key constraints:
+     • No daemon running
+     • Must work offline
+     • Single user
+
+                  SQLite          Postgres
+     Deployment   embedded ✓      needs server ✗
+     Offline      yes ✓           no ✗
+     Single file  yes ✓           no ✗
+
+     SQLite. Not even close.
+
+     Unless... is there a sync component?
+```
+
+---
+
+## Ending Discovery
+
+There's no required ending. Discovery might:
+
+- **Flow into a proposal**: "Ready to start? I can create a change proposal."
+- **Result in artifact updates**: "Updated design.md with these decisions"
+- **Just provide clarity**: User has what they need, moves on
+- **Continue later**: "We can pick this up anytime"
+
+When it feels like things are crystallizing, you might summarize:
+
+```
+## What We Figured Out
+
+**The problem**: [crystallized understanding]
+
+**The approach**: [if one emerged]
+
+**Open questions**: [if any remain]
+
+**Next steps** (if ready):
+- Create a change proposal
+- Keep exploring: just keep talking
+```
+
+But this summary is optional. Sometimes the thinking IS the value.
+
+---
+
+## Guardrails
+
+- **Don't implement** - Never write code or implement features. Creating OpenSpec artifacts is fine, writing application code is not.
+- **Don't fake understanding** - If something is unclear, dig deeper
+- **Don't rush** - Discovery is thinking time, not task time
+- **Don't force structure** - Let patterns emerge naturally
+- **Don't auto-capture** - Offer to save insights, don't just do it
+- **Do visualize** - A good diagram is worth many paragraphs
+- **Do explore the codebase** - Ground discussions in reality
+- **Do question assumptions** - Including the user's and your own

--- a/.claude/skills/openspec-new-change/SKILL.md
+++ b/.claude/skills/openspec-new-change/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: openspec-new-change
+description: Start a new OpenSpec change using the experimental artifact workflow. Use when the user wants to create a new feature, fix, or modification with a structured step-by-step approach.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.1"
+---
+
+Start a new change using the experimental artifact-driven approach.
+
+**Input**: The user's request should include a change name (kebab-case) OR a description of what they want to build.
+
+**Steps**
+
+1. **If no clear input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Determine the workflow schema**
+
+   Use the default schema (omit `--schema`) unless the user explicitly requests a different workflow.
+
+   **Use a different schema only if the user mentions:**
+   - A specific schema name → use `--schema <name>`
+   - "show workflows" or "what workflows" → run `openspec schemas --json` and let them choose
+
+   **Otherwise**: Omit `--schema` to use the default.
+
+3. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   Add `--schema <name>` only if the user requested a specific workflow.
+   This creates a scaffolded change at `openspec/changes/<name>/` with the selected schema.
+
+4. **Show the artifact status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+   This shows which artifacts need to be created and which are ready (dependencies satisfied).
+
+5. **Get instructions for the first artifact**
+   The first artifact depends on the schema (e.g., `proposal` for spec-driven).
+   Check the status output to find the first artifact with status "ready".
+   ```bash
+   openspec instructions <first-artifact-id> --change "<name>"
+   ```
+   This outputs the template and context for creating the first artifact.
+
+6. **STOP and wait for user direction**
+
+**Output**
+
+After completing the steps, summarize:
+- Change name and location
+- Schema/workflow being used and its artifact sequence
+- Current status (0/N artifacts complete)
+- The template for the first artifact
+- Prompt: "Ready to create the first artifact? Just describe what this change is about and I'll draft it, or ask me to continue."
+
+**Guardrails**
+- Do NOT create any artifacts yet - just show the instructions
+- Do NOT advance beyond showing the first artifact template
+- If the name is invalid (not kebab-case), ask for a valid name
+- If a change with that name already exists, suggest continuing that change instead
+- Pass --schema if using a non-default workflow

--- a/.claude/skills/openspec-propose/SKILL.md
+++ b/.claude/skills/openspec-propose/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: openspec-propose
+description: Propose a new change with all artifacts generated in one step. Use when the user wants to quickly describe what they want to build and get a complete proposal with design, specs, and tasks ready for implementation.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.1"
+---
+
+Propose a new change - create the change and generate all artifacts in one step.
+
+I'll create a change with artifacts:
+- proposal.md (what & why)
+- design.md (how)
+- tasks.md (implementation steps)
+
+When ready to implement, run /opsx:apply
+
+---
+
+**Input**: The user's request should include a change name (kebab-case) OR a description of what they want to build.
+
+**Steps**
+
+1. **If no clear input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change at `openspec/changes/<name>/` with `.openspec.yaml`.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts with their status and dependencies
+
+4. **Create artifacts in sequence until apply-ready**
+
+   Use the **TodoWrite tool** to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `outputPath`: Where to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context
+      - Create the artifact file using `template` as the structure
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "Created <artifact-id>"
+
+   b. **Continue until all `applyRequires` artifacts are complete**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
+      - Stop when all `applyRequires` artifacts are done
+
+   c. **If an artifact requires user input** (unclear context):
+      - Use **AskUserQuestion tool** to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions
+- What's ready: "All artifacts created! Ready for implementation."
+- Prompt: "Run `/opsx:apply` or ask me to implement to start working on the tasks."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
+- Always read dependency artifacts before creating a new one
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, ask if user wants to continue it or create a new one
+- Verify each artifact file exists after writing before proceeding to next

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,4 @@
 {
+  "root": true,
   "extends": ["next/core-web-vitals", "next/typescript"]
 }

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,8 +3,8 @@ name: Deploy static content to Pages
 
 on:
   # Runs on pushes targeting the default branch
-  push:
-    branches: ['main']
+  # push:
+    # branches: ['main']
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/openspec/changes/archive/2026-05-10-migrate-storage-to-indexeddb/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-10-migrate-storage-to-indexeddb/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-10

--- a/openspec/changes/archive/2026-05-10-migrate-storage-to-indexeddb/design.md
+++ b/openspec/changes/archive/2026-05-10-migrate-storage-to-indexeddb/design.md
@@ -1,0 +1,94 @@
+## Context
+
+`training.service.ts` currently calls `localStorage.getItem` / `localStorage.setItem` synchronously on every save and load. The whole JSON array of trainings is serialised/deserialised on each operation. As history grows this blocks the main thread and risks hitting the 5 MB browser quota without warning. IndexedDB provides an async, transactional, keyed object-store API with a quota measured in hundreds of MB.
+
+No data-model changes are needed — the existing `Training` interface maps cleanly to an IndexedDB record keyed by `Training.date`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- All storage reads/writes are non-blocking (async/await).
+- Service layer returns `Result<T, Error>` — no unhandled throws reach components.
+- Existing localStorage data is migrated automatically on first run.
+- Unit tests run without a real browser (fake-indexeddb in jsdom).
+
+**Non-Goals:**
+- Supabase / server-side sync (no change).
+- Changes to `Training`, `TrainingSteps`, or `Asana` model shapes.
+- Offline service-worker caching.
+- Multi-tab conflict resolution.
+
+## Decisions
+
+### 1. `idb` wrapper library vs raw IndexedDB API
+
+**Decision**: use the [`idb`](https://github.com/jakearchibald/idb) package (≈ 1 kB gzipped).
+
+| Option | Pros | Cons |
+|---|---|---|
+| Raw IDB | Zero new dep | `IDBRequest` callbacks are verbose; easy to miss `onerror` paths |
+| `idb` | Typed, Promise-based, minimal | One extra package |
+| Dexie.js | Full ORM, reactive queries | 22 kB, far more than needed |
+
+`idb` gives clean `async/await` semantics without imposing an ORM layer. Raw IDB would require wrapping every request manually — error-prone and harder to test.
+
+### 2. Database initialisation
+
+A single `openDB` call is made lazily in `src/lib/db.ts` and the resulting `Promise<IDBPDatabase>` is cached in module scope. All service functions `await` the cached promise before issuing requests. This avoids repeated open calls and keeps upgrade logic in one place.
+
+```
+src/lib/db.ts
+  export const getDb = () => cachedDbPromise   // lazy singleton
+```
+
+Schema: one object store `"trainings"` with `keyPath: "date"`.
+
+### 3. Service API shape
+
+`saveTraining` and `getTrainings` become `async` and return `Promise<Result<…, Error>>`.
+
+```ts
+saveTraining(training: Training): Promise<Result<void, Error>>
+getTrainings(date: string): Promise<Result<Training | undefined, Error>>
+```
+
+Callers (TrainingPage) must `await` and handle the `ok`/`error` branch. A component-level loading state is added to cover the async gap.
+
+### 4. localStorage → IndexedDB migration
+
+On the first `getDb()` call (inside the `upgrade` callback at version bump from 0 → 1) we cannot access localStorage (upgrade runs synchronously in the IDB transaction context). Instead, migration runs as a one-shot async step after the DB is opened:
+
+1. Check `localStorage.getItem('trainings')` — if present, parse and `put` each record into the IDB store.
+2. On success, delete the `localStorage` key.
+3. Wrap in try/catch; a migration failure returns an `error` Result but does **not** crash the app — data remains in localStorage as fallback evidence.
+
+This follows the project convention: shape changes require a migration in `src/services/`.
+
+### 5. Testing strategy
+
+`fake-indexeddb` is added as a dev-dependency. It provides a spec-compliant in-memory IndexedDB that works inside jsdom. Tests import `src/lib/db.ts` after replacing `indexedDB` with the fake via `vi.stubGlobal`. Each test gets a fresh DB instance by clearing the module cache between tests.
+
+## Risks / Trade-offs
+
+| Risk | Mitigation |
+|---|---|
+| IndexedDB unavailable (some private-browsing modes) | `openDB` is wrapped in try/catch; service returns `{ ok: false, error }` — UI shows a toast/fallback |
+| Migration runs twice if page is closed mid-migration | Migration is idempotent: `put` overwrites and the localStorage key is only cleared after all puts succeed |
+| Async API adds loading state complexity to `TrainingPage` | Add a single `isLoading` boolean to TrainingPage state; show a spinner while the initial load resolves |
+| `idb` package version drift | Pin to a minor version in `package.json` |
+
+## Migration Plan
+
+1. Install `idb` (runtime) and `fake-indexeddb` (dev).
+2. Add `src/lib/db.ts` — DB open/upgrade, export `getDb`.
+3. Rewrite `src/services/training.service.ts` — async, Result-typed, calls `getDb()`.
+4. Add legacy-migration helper called once from `getDb()` post-open.
+5. Update `TrainingPage` to `await` service calls and manage `isLoading`.
+6. Replace localStorage-based tests with `fake-indexeddb`-based tests.
+7. Manual smoke test: seed old data in localStorage → reload → verify data appears → verify localStorage key is gone.
+
+**Rollback**: revert service file to previous commit; localStorage data is preserved if migration fails (key is only cleared on success).
+
+## Open Questions
+
+- Should `saveTraining` upsert (replace by date) or append? Current localStorage impl appends and callers search by date — upsert with `keyPath: "date"` is cleaner and fixes the implicit duplicate-date bug. **Decision: upsert.** Confirmed by user.

--- a/openspec/changes/archive/2026-05-10-migrate-storage-to-indexeddb/proposal.md
+++ b/openspec/changes/archive/2026-05-10-migrate-storage-to-indexeddb/proposal.md
@@ -1,0 +1,38 @@
+## Why
+
+`localStorage` is synchronous and blocks the main thread on every read/write, has a hard ~5 MB quota, and offers no transaction semantics. As training history grows, this degrades UI responsiveness and risks silent data loss on quota overflow. Migrating to IndexedDB gives async, non-blocking storage with significantly higher capacity and proper transactional guarantees.
+
+## What Changes
+
+- Replace all `localStorage` reads/writes in `src/services/training.service.ts` with IndexedDB operations.
+- The public service API (`saveTraining`, `getTrainings`) becomes **async** — returns `Promise`-wrapped `Result` types. **BREAKING**: all callers must `await` these calls.
+- Add an IndexedDB initialisation helper in `src/lib/` that opens/upgrades the database and exports a typed handle.
+- Update `TrainingPage` (and any other consumers) to handle the now-async service calls.
+- Add a one-time migration that reads any existing `localStorage` data on first load and writes it into IndexedDB, then clears the localStorage key.
+
+## Non-goals
+
+- No server-side or Supabase sync as part of this change.
+- No changes to the `Training` or `TrainingSteps` data models.
+- No changes to drag-and-drop state management.
+- No offline/service-worker caching layer.
+
+## Capabilities
+
+### New Capabilities
+
+- `training-storage`: Async, IndexedDB-backed persistence for `Training` records — open/upgrade DB, save a training, retrieve training by date, and migrate legacy localStorage data on first run.
+
+### Modified Capabilities
+
+*(none — no existing spec files exist; the storage behaviour change is fully captured by the new capability above)*
+
+## Impact
+
+| Area | Change |
+|---|---|
+| `src/services/training.service.ts` | Full rewrite to async IndexedDB calls |
+| `src/lib/db.ts` *(new)* | IndexedDB open/upgrade helper |
+| `src/components/pages/training-page/` | Await async service calls; handle loading state |
+| `src/services/training.service.test.ts` | Rewrite tests using fake IndexedDB (`fake-indexeddb`) |
+| `package.json` | Add `fake-indexeddb` dev-dependency for tests |

--- a/openspec/changes/archive/2026-05-10-migrate-storage-to-indexeddb/specs/training-storage/spec.md
+++ b/openspec/changes/archive/2026-05-10-migrate-storage-to-indexeddb/specs/training-storage/spec.md
@@ -1,0 +1,63 @@
+## ADDED Requirements
+
+### Requirement: Database initialisation
+The system SHALL open an IndexedDB database named `"yoga-dashboard"` at version 1 with a single object store `"trainings"` keyed by the `date` field. The open operation SHALL be exposed as a lazy-initialised cached Promise via `src/lib/db.ts`.
+
+#### Scenario: First open creates the object store
+- **WHEN** the database does not yet exist in the browser
+- **THEN** IndexedDB creates the database at version 1 with a `"trainings"` object store keyed by `date`
+
+#### Scenario: Subsequent opens reuse the cached connection
+- **WHEN** `getDb()` is called more than once
+- **THEN** the same `IDBPDatabase` instance is returned without reopening the database
+
+---
+
+### Requirement: Save training record
+`saveTraining` SHALL persist a `Training` record to the `"trainings"` IndexedDB object store, upserting by `date` key. It SHALL return `Promise<Result<void, Error>>`.
+
+#### Scenario: Successful save of a new training
+- **WHEN** `saveTraining` is called with a `Training` whose `date` does not exist in the store
+- **THEN** the record is inserted and the function resolves `{ ok: true, value: undefined }`
+
+#### Scenario: Upsert replaces existing training for the same date
+- **WHEN** `saveTraining` is called with a `Training` whose `date` already exists in the store
+- **THEN** the existing record is replaced and the function resolves `{ ok: true, value: undefined }`
+
+#### Scenario: Save fails when IndexedDB is unavailable
+- **WHEN** the IndexedDB database cannot be opened (e.g., private-browsing restriction)
+- **THEN** `saveTraining` resolves `{ ok: false, error: <Error> }` without throwing
+
+---
+
+### Requirement: Retrieve training by date
+`getTrainings` SHALL query the `"trainings"` object store for a record matching the given date string. It SHALL return `Promise<Result<Training | undefined, Error>>`.
+
+#### Scenario: Training found for requested date
+- **WHEN** `getTrainings` is called with a date that exists in the store
+- **THEN** the function resolves `{ ok: true, value: <Training> }`
+
+#### Scenario: No training found for requested date
+- **WHEN** `getTrainings` is called with a date that does not exist in the store
+- **THEN** the function resolves `{ ok: true, value: undefined }`
+
+#### Scenario: Read fails when IndexedDB is unavailable
+- **WHEN** the IndexedDB database cannot be opened
+- **THEN** `getTrainings` resolves `{ ok: false, error: <Error> }` without throwing
+
+---
+
+### Requirement: Legacy localStorage migration
+On the first successful database open, the system SHALL migrate any training records stored under the `"trainings"` key in `localStorage` into the IndexedDB store, then remove the `localStorage` key.
+
+#### Scenario: Migration runs when localStorage data is present
+- **WHEN** the database is opened for the first time and `localStorage.getItem("trainings")` returns a non-empty JSON array
+- **THEN** each record is upserted into the IndexedDB `"trainings"` store and `localStorage.removeItem("trainings")` is called
+
+#### Scenario: Migration is skipped when no legacy data exists
+- **WHEN** the database is opened and `localStorage.getItem("trainings")` returns `null`
+- **THEN** no writes are made to IndexedDB and localStorage is not modified
+
+#### Scenario: Migration failure does not crash the application
+- **WHEN** an error occurs during migration (e.g., malformed JSON in localStorage)
+- **THEN** the error is caught, the application continues to function, and the localStorage key is left intact

--- a/openspec/changes/archive/2026-05-10-migrate-storage-to-indexeddb/tasks.md
+++ b/openspec/changes/archive/2026-05-10-migrate-storage-to-indexeddb/tasks.md
@@ -1,0 +1,36 @@
+## 1. Dependencies & Setup
+
+- [x] 1.1 Install `idb` as a runtime dependency and `fake-indexeddb` as a dev dependency (`npm install idb` and `npm install -D fake-indexeddb`)
+- [x] 1.2 Verify TypeScript picks up `idb` types — run `npx tsc --noEmit` and confirm no missing-module errors
+
+## 2. Database Layer — Tests First (TDD)
+
+- [x] 2.1 Write failing tests for `src/lib/db.ts`: verify `getDb()` returns a database with a `"trainings"` object store, and that repeated calls return the same instance (use `fake-indexeddb`)
+- [x] 2.2 Implement `src/lib/db.ts`: lazy `openDB` singleton with `upgrade` callback creating the `"trainings"` store keyed by `date`; export `getDb`
+- [x] 2.3 Confirm db tests pass: `npm test`
+
+## 3. Training Service — Tests First (TDD)
+
+- [x] 3.1 Write failing tests for `saveTraining`: new record inserts, same-date record upserts, and IndexedDB-unavailable error path (use `fake-indexeddb` + `vi.stubGlobal`)
+- [x] 3.2 Write failing tests for `getTrainings`: found-by-date, not-found returns `undefined`, and error path
+- [x] 3.3 Implement `saveTraining` in `src/services/training.service.ts` as `async`, returning `Promise<Result<void, Error>>`, using `idb` via `getDb()`
+- [x] 3.4 Implement `getTrainings` as `async`, returning `Promise<Result<Training | undefined, Error>>`
+- [x] 3.5 Confirm service tests pass: `npm test`
+
+## 4. Legacy Migration — Tests First (TDD)
+
+- [x] 4.1 Write failing tests for the migration helper: localStorage-present migrates all records and clears the key; localStorage-absent is a no-op; malformed JSON is caught and localStorage key is preserved
+- [x] 4.2 Implement `migrateFromLocalStorage` in `src/services/training.service.ts` (called once after `getDb()` resolves on app start)
+- [x] 4.3 Confirm migration tests pass: `npm test`
+
+## 5. TrainingPage Integration
+
+- [x] 5.1 Update `TrainingPage` to `await` `saveTraining` and `getTrainings`, adding an `isLoading` boolean state; render a loading indicator while the initial fetch is in-flight
+- [x] 5.2 Handle `ok: false` results in `TrainingPage` — surface an error message to the user rather than silently failing
+- [ ] 5.3 Manually smoke-test: seed data in `localStorage` under key `"trainings"`, reload, verify data loads correctly, verify `localStorage` key is removed
+
+## 6. Verification
+
+- [x] 6.1 `npm run lint` — zero warnings
+- [x] 6.2 `npx tsc --noEmit` — zero errors
+- [x] 6.3 `npm test` — all tests pass

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,74 @@
+schema: spec-driven
+
+context: |
+  ## Project
+  Yoga Dashboard — a Next.js 14 App Router application for creating and managing
+  yoga training sequences via drag-and-drop.
+
+  ## Tech Stack
+  - Framework: Next.js 14 (App Router, TypeScript strict mode)
+  - Language: TypeScript 5
+  - Styling: Tailwind CSS 3 + CSS Modules per component
+  - Drag & Drop: @dnd-kit/core
+  - Testing: Vitest + @testing-library/react + jsdom
+  - Linting: ESLint (next/core-web-vitals config)
+  - Backend/DB: Supabase (public-anon key only; service-role keys are never
+    placed in NEXT_PUBLIC_* envs)
+  - Persistence: localStorage (versioned — bump a version key and add a
+    migration in src/services/ for any shape change)
+
+  ## Repository Layout
+  src/
+    app/           — Next.js pages and API routes
+    components/    — Feature-scoped React components (CSS module per component)
+    constants/     — Static data: asana definitions, training-step names
+    models/        — TypeScript interfaces and type definitions
+    services/      — Business logic and localStorage persistence
+    lib/           — Supabase client config
+    utils/         — Pure utility functions
+
+  ## Domain Concepts
+  - Asana: a yoga pose with English/Sanskrit names, description, benefits, image
+  - Training: date-keyed record with steps → asana-identifier arrays
+  - TrainingSteps: { setup, warm-up, workout, cool-down, stretching, shavasanah }
+  - Drag-and-drop state lives exclusively in TrainingPage; never duplicated in
+    TrainingStep or AsanaCard
+
+  ## Code Style & Conventions
+  - Files: kebab-case  |  Variables/functions: camelCase
+  - Types/interfaces/classes: PascalCase  |  Constants/enum values: ALL_CAPS
+  - Generic type params: T-prefix (TKey, TValue)
+  - Prefer `import type` for type-only imports
+  - No new enums — use `as const` objects instead
+  - Error handling: Result<T, E> pattern (ok/error) instead of throwing
+  - Avoid `any` except in generic functions where inference fails
+  - JSDoc only when behavior is non-obvious; be concise
+  - No explanatory comments; name identifiers well instead
+
+  ## Commit Convention
+  Conventional commits: feat / fix / refactor / test / chore / docs
+
+  ## Engineering Process
+  - Planning entry point: /opsx:propose
+  - Implementation: /opsx:apply — always in a git worktree, TDD (RED-GREEN-REFACTOR)
+  - Verification before completing any task:
+      npm run lint   (zero warnings)
+      npx tsc --noEmit  (zero errors)
+      npm test       (all pass)
+  - Code review after every 3-5 tasks; CRITICAL/HIGH findings block progress
+  - Archive with /opsx:archive after deploy + sanity check
+
+rules:
+  proposal:
+    - State the problem and motivation in ≤ 3 sentences before any solution
+    - Include a "Non-goals" section to bound scope
+    - List affected files/directories when known
+  design:
+    - Reference existing src/models/ types; introduce new types only when necessary
+    - Call out localStorage migration needs explicitly if data shape changes
+    - Note any Supabase interactions and confirm public-anon key is sufficient
+  tasks:
+    - Each task must be completable in ≤ 2 hours; split larger tasks
+    - Every task that touches src/ must include a corresponding test task
+    - Order tasks so tests are written before implementation (TDD)
+    - Verification (lint + tsc + test) is the final task of every change

--- a/openspec/specs/training-storage/spec.md
+++ b/openspec/specs/training-storage/spec.md
@@ -1,0 +1,65 @@
+# Training Storage Specification
+
+## Requirements
+
+### Requirement: Database initialisation
+The system SHALL open an IndexedDB database named `"yoga-dashboard"` at version 1 with a single object store `"trainings"` keyed by the `date` field. The open operation SHALL be exposed as a lazy-initialised cached Promise via `src/lib/db.ts`.
+
+#### Scenario: First open creates the object store
+- **WHEN** the database does not yet exist in the browser
+- **THEN** IndexedDB creates the database at version 1 with a `"trainings"` object store keyed by `date`
+
+#### Scenario: Subsequent opens reuse the cached connection
+- **WHEN** `getDb()` is called more than once
+- **THEN** the same `IDBPDatabase` instance is returned without reopening the database
+
+---
+
+### Requirement: Save training record
+`saveTraining` SHALL persist a `Training` record to the `"trainings"` IndexedDB object store, upserting by `date` key. It SHALL return `Promise<Result<void, Error>>`.
+
+#### Scenario: Successful save of a new training
+- **WHEN** `saveTraining` is called with a `Training` whose `date` does not exist in the store
+- **THEN** the record is inserted and the function resolves `{ ok: true, value: undefined }`
+
+#### Scenario: Upsert replaces existing training for the same date
+- **WHEN** `saveTraining` is called with a `Training` whose `date` already exists in the store
+- **THEN** the existing record is replaced and the function resolves `{ ok: true, value: undefined }`
+
+#### Scenario: Save fails when IndexedDB is unavailable
+- **WHEN** the IndexedDB database cannot be opened (e.g., private-browsing restriction)
+- **THEN** `saveTraining` resolves `{ ok: false, error: <Error> }` without throwing
+
+---
+
+### Requirement: Retrieve training by date
+`getTrainings` SHALL query the `"trainings"` object store for a record matching the given date string. It SHALL return `Promise<Result<Training | undefined, Error>>`.
+
+#### Scenario: Training found for requested date
+- **WHEN** `getTrainings` is called with a date that exists in the store
+- **THEN** the function resolves `{ ok: true, value: <Training> }`
+
+#### Scenario: No training found for requested date
+- **WHEN** `getTrainings` is called with a date that does not exist in the store
+- **THEN** the function resolves `{ ok: true, value: undefined }`
+
+#### Scenario: Read fails when IndexedDB is unavailable
+- **WHEN** the IndexedDB database cannot be opened
+- **THEN** `getTrainings` resolves `{ ok: false, error: <Error> }` without throwing
+
+---
+
+### Requirement: Legacy localStorage migration
+On the first successful database open, the system SHALL migrate any training records stored under the `"trainings"` key in `localStorage` into the IndexedDB store, then remove the `localStorage` key.
+
+#### Scenario: Migration runs when localStorage data is present
+- **WHEN** the database is opened for the first time and `localStorage.getItem("trainings")` returns a non-empty JSON array
+- **THEN** each record is upserted into the IndexedDB `"trainings"` store and `localStorage.removeItem("trainings")` is called
+
+#### Scenario: Migration is skipped when no legacy data exists
+- **WHEN** the database is opened and `localStorage.getItem("trainings")` returns `null`
+- **THEN** no writes are made to IndexedDB and localStorage is not modified
+
+#### Scenario: Migration failure does not crash the application
+- **WHEN** an error occurs during migration (e.g., malformed JSON in localStorage)
+- **THEN** the error is caught, the application continues to function, and the localStorage key is left intact

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@dnd-kit/core": "^6.1.0",
+        "idb": "^8.0.3",
         "next": "14.2.13",
         "react": "^18",
         "react-dom": "^18"
@@ -21,6 +22,7 @@
         "@vitejs/plugin-react": "^6.0.1",
         "eslint": "^8",
         "eslint-config-next": "14.2.13",
+        "fake-indexeddb": "^6.2.5",
         "jsdom": "^29.1.1",
         "postcss": "^8",
         "tailwindcss": "^3.4.1",
@@ -2964,6 +2966,16 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/fake-indexeddb": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.2.5.tgz",
+      "integrity": "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3413,6 +3425,12 @@
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
+    },
+    "node_modules/idb": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-8.0.3.tgz",
+      "integrity": "sha512-LtwtVyVYO5BqRvcsKuB2iUMnHwPVByPCXFXOpuU96IZPPoPN6xjOGxZQ74pgSVVLQWtUOYgyeL4GE98BY5D3wg==",
+      "license": "ISC"
     },
     "node_modules/ignore": {
       "version": "5.3.2",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@dnd-kit/core": "^6.1.0",
+    "idb": "^8.0.3",
     "next": "14.2.13",
     "react": "^18",
     "react-dom": "^18"
@@ -23,6 +24,7 @@
     "@vitejs/plugin-react": "^6.0.1",
     "eslint": "^8",
     "eslint-config-next": "14.2.13",
+    "fake-indexeddb": "^6.2.5",
     "jsdom": "^29.1.1",
     "postcss": "^8",
     "tailwindcss": "^3.4.1",

--- a/src/components/pages/training-page/training-page.module.css
+++ b/src/components/pages/training-page/training-page.module.css
@@ -73,6 +73,20 @@
     align-items: stretch;
 }
 
+.errorBanner {
+    padding: 10px 16px;
+    background: #fee2e2;
+    color: #991b1b;
+    border-radius: var(--radius-md);
+    font-size: 0.9em;
+}
+
+.loadingIndicator {
+    padding: var(--space-6);
+    text-align: center;
+    color: var(--color-text-muted, #6b7280);
+}
+
 .aiNotification {
     position: fixed;
     top: 20px;

--- a/src/components/pages/training-page/training-page.tsx
+++ b/src/components/pages/training-page/training-page.tsx
@@ -9,7 +9,7 @@ import { STEPS } from '@/constants/steps';
 import { DndContext, DragEndEvent, DragOverlay, DragStartEvent, MouseSensor, TouchSensor, useSensor, useSensors } from '@dnd-kit/core';
 import { type ChangeEvent, useCallback, useEffect, useState } from 'react';
 import type { TrainingSteps } from '@/models/training.model';
-import { getTrainings, saveTraining } from '@/services/training.service';
+import { getTraining, saveTraining, migrateFromLocalStorage } from '@/services/training.service';
 
 interface TrainingPageProps {
   trainingDate?: Date;
@@ -20,16 +20,29 @@ export const TrainingPage = ({trainingDate: propsTrainingDate}: TrainingPageProp
   const [trainingDate, setTrainingDate] = useState(propsTrainingDate || new Date());
   const [showAIAppliedNotification, setShowAIAppliedNotification] = useState(false);
   const [activeDragId, setActiveDragId] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [storageError, setStorageError] = useState<string | null>(null);
 
   const sensors = useSensors(
     useSensor(MouseSensor, { activationConstraint: { distance: 8 } }),
     useSensor(TouchSensor, { activationConstraint: { delay: 250, tolerance: 5 } }),
   );
 
-  const setTrainingFromTheDate = useCallback((date: Date) => {
-    const storedTrainings = getTrainings(formatDate(date));
-    if (storedTrainings) {
-      setTrainingSteps(storedTrainings.steps);
+  useEffect(() => {
+    migrateFromLocalStorage();
+  }, []);
+
+  const setTrainingFromTheDate = useCallback(async (date: Date) => {
+    setIsLoading(true);
+    setStorageError(null);
+    const result = await getTraining(formatDate(date));
+    setIsLoading(false);
+    if (!result.ok) {
+      setStorageError('Failed to load training data. Please try again.');
+      return;
+    }
+    if (result.value) {
+      setTrainingSteps(result.value.steps);
     }
   }, []);
 
@@ -50,19 +63,16 @@ export const TrainingPage = ({trainingDate: propsTrainingDate}: TrainingPageProp
     if (overTrainingStep) {
       setTrainingSteps((prevTrainingSteps) => {
         const newTrainingSteps = {...prevTrainingSteps};
-        
-        // Remove asana from all previous steps
+
         Object.keys(newTrainingSteps).forEach((step) => {
           newTrainingSteps[step] = newTrainingSteps[step].filter((asana) => asana !== draggingAsanaCard.id);
         });
-        
-        // Add asana to the target step
+
         newTrainingSteps[overTrainingStep.id] = [...(newTrainingSteps[overTrainingStep.id] || []), draggingAsanaCard.id];
-        
+
         return newTrainingSteps;
       });
     } else {
-      // remove from prev holding steps
       const newTrainingSteps = {...trainingSteps};
       Object.keys(newTrainingSteps).forEach((step) => {
         newTrainingSteps[step] = newTrainingSteps[step].filter((asana) => asana !== draggingAsanaCard.id);
@@ -92,16 +102,19 @@ export const TrainingPage = ({trainingDate: propsTrainingDate}: TrainingPageProp
     setTrainingDate(date);
   }
 
-  function onSaveClick() {
+  async function onSaveClick() {
     if (Object.keys(trainingSteps).length) {
-      saveTraining({date: formatDate(trainingDate), steps: trainingSteps});
+      setStorageError(null);
+      const result = await saveTraining({date: formatDate(trainingDate), steps: trainingSteps});
+      if (!result.ok) {
+        setStorageError('Failed to save training. Please try again.');
+      }
     }
   }
 
   function handleAITrainingPlan(aiTrainingSteps: TrainingSteps) {
     setTrainingSteps(aiTrainingSteps);
     setShowAIAppliedNotification(true);
-    // Hide notification after 4 seconds
     setTimeout(() => setShowAIAppliedNotification(false), 4000);
   }
 
@@ -112,17 +125,24 @@ export const TrainingPage = ({trainingDate: propsTrainingDate}: TrainingPageProp
         <header className={styles.header}>
           <h1 className={styles.headerTitle}>Training</h1>
           <input type="date" value={formatDate(trainingDate)} onChange={onDateChange} className={styles.dateInput}/>
-          <button className={styles.saveButton} onClick={onSaveClick}>Save</button>
+          <button className={styles.saveButton} onClick={onSaveClick} disabled={isLoading}>Save</button>
         </header>
 
-        <section className={styles.container}>
-          {STEPS.map((step) => (
-            <TrainingStep step={step}  key={step}>
-              {getDraggableChildren(step)}
-            </TrainingStep>
-          ))}
-        </section>
+        {storageError && (
+          <div role="alert" className={styles.errorBanner}>{storageError}</div>
+        )}
 
+        {isLoading ? (
+          <div className={styles.loadingIndicator}>Loading…</div>
+        ) : (
+          <section className={styles.container}>
+            {STEPS.map((step) => (
+              <TrainingStep step={step} key={step}>
+                {getDraggableChildren(step)}
+              </TrainingStep>
+            ))}
+          </section>
+        )}
 
         <section className={styles.library}>
           <h2 className={styles.sectionLabel}>Asana library</h2>
@@ -131,7 +151,7 @@ export const TrainingPage = ({trainingDate: propsTrainingDate}: TrainingPageProp
           </div>
         </section>
       </main>
-      
+
       {showAIAppliedNotification && (
         <div className={styles.aiNotification}>
           ✨ AI yoga sequence applied successfully! Check your training steps.

--- a/src/lib/db.test.ts
+++ b/src/lib/db.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import 'fake-indexeddb/auto';
+
+describe('getDb', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('returns a database with a trainings object store', async () => {
+    const { getDb } = await import('./db');
+    const db = await getDb();
+    expect(db.objectStoreNames.contains('trainings')).toBe(true);
+  });
+
+  it('returns the same instance on repeated calls', async () => {
+    const { getDb } = await import('./db');
+    const first = await getDb();
+    const second = await getDb();
+    expect(first).toBe(second);
+  });
+});

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,0 +1,20 @@
+import { openDB } from 'idb';
+import type { IDBPDatabase } from 'idb';
+
+const DB_NAME = 'yoga-dashboard';
+const DB_VERSION = 1;
+
+let dbPromise: Promise<IDBPDatabase> | null = null;
+
+export const getDb = (): Promise<IDBPDatabase> => {
+  if (!dbPromise) {
+    dbPromise = openDB(DB_NAME, DB_VERSION, {
+      upgrade(db) {
+        if (!db.objectStoreNames.contains('trainings')) {
+          db.createObjectStore('trainings', { keyPath: 'date' });
+        }
+      },
+    });
+  }
+  return dbPromise;
+};

--- a/src/services/training.service.migration.test.ts
+++ b/src/services/training.service.migration.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import 'fake-indexeddb/auto';
+import { IDBFactory } from 'fake-indexeddb';
+
+function makeMockStorage(initial?: string): Storage {
+  const store: Record<string, string> = initial ? { trainings: initial } : {};
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => { store[key] = value; },
+    removeItem: (key: string) => { delete store[key]; },
+    clear: () => { Object.keys(store).forEach(k => delete store[k]); },
+    key: (index: number) => Object.keys(store)[index] ?? null,
+    get length() { return Object.keys(store).length; },
+  };
+}
+
+describe('migrateFromLocalStorage', () => {
+  beforeEach(() => {
+    vi.doUnmock('@/lib/db');
+    vi.resetModules();
+    vi.stubGlobal('indexedDB', new IDBFactory());
+  });
+
+  it('migrates records from localStorage into IndexedDB and removes the key', async () => {
+    const records = [
+      { date: '2024-01-01', steps: { 'warm-up': ['Mountain Pose'] } },
+      { date: '2024-01-02', steps: { workout: ['Warrior I'] } },
+    ];
+    vi.stubGlobal('localStorage', makeMockStorage(JSON.stringify(records)));
+
+    const { migrateFromLocalStorage, getTraining } = await import('./training.service');
+    await migrateFromLocalStorage();
+
+    const first = await getTraining('2024-01-01');
+    const second = await getTraining('2024-01-02');
+    expect(first.ok && first.value?.date).toBe('2024-01-01');
+    expect(second.ok && second.value?.date).toBe('2024-01-02');
+    expect(localStorage.getItem('trainings')).toBeNull();
+  });
+
+  it('is a no-op when localStorage has no trainings key', async () => {
+    vi.stubGlobal('localStorage', makeMockStorage());
+
+    const { migrateFromLocalStorage, getTraining } = await import('./training.service');
+    await migrateFromLocalStorage();
+
+    const result = await getTraining('2024-01-01');
+    expect(result.ok && result.value).toBeUndefined();
+  });
+
+  it('leaves localStorage intact when JSON is malformed', async () => {
+    vi.stubGlobal('localStorage', makeMockStorage('not-valid-json'));
+
+    const { migrateFromLocalStorage } = await import('./training.service');
+    await expect(migrateFromLocalStorage()).resolves.not.toThrow();
+    expect(localStorage.getItem('trainings')).toBe('not-valid-json');
+  });
+});

--- a/src/services/training.service.test.ts
+++ b/src/services/training.service.test.ts
@@ -1,63 +1,76 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { saveTraining, getTrainings } from './training.service';
+import 'fake-indexeddb/auto';
+import { IDBFactory } from 'fake-indexeddb';
 import type { Training } from '@/models/training.model';
 
 const mockTraining: Training = {
   date: '2024-03-15',
-  steps: {
-    'warm-up': ['Mountain Pose', 'Downward-Facing Dog'],
-    'workout': ['Warrior I', 'Warrior II'],
-  },
+  steps: { 'warm-up': ['Mountain Pose', 'Downward-Facing Dog'] },
 };
-
-function makeMockStorage(): Storage {
-  const store: Record<string, string> = {};
-  return {
-    getItem: (key: string) => store[key] ?? null,
-    setItem: (key: string, value: string) => { store[key] = value; },
-    removeItem: (key: string) => { delete store[key]; },
-    clear: () => { Object.keys(store).forEach(k => delete store[k]); },
-    key: (index: number) => Object.keys(store)[index] ?? null,
-    get length() { return Object.keys(store).length; },
-  };
-}
 
 describe('training.service', () => {
   beforeEach(() => {
-    vi.stubGlobal('localStorage', makeMockStorage());
+    vi.doUnmock('@/lib/db');
+    vi.resetModules();
+    vi.stubGlobal('indexedDB', new IDBFactory());
   });
 
   describe('saveTraining', () => {
-    it('persists a training to localStorage', () => {
-      saveTraining(mockTraining);
-      const stored = JSON.parse(localStorage.getItem('trainings') ?? '[]') as Training[];
-      expect(stored).toHaveLength(1);
-      expect(stored[0].date).toBe('2024-03-15');
+    it('inserts a new training record and resolves ok', async () => {
+      const { saveTraining } = await import('./training.service');
+      const result = await saveTraining(mockTraining);
+      expect(result.ok).toBe(true);
     });
 
-    it('appends to existing trainings', () => {
-      const second: Training = { date: '2024-03-16', steps: {} };
-      saveTraining(mockTraining);
-      saveTraining(second);
-      const stored = JSON.parse(localStorage.getItem('trainings') ?? '[]') as Training[];
-      expect(stored).toHaveLength(2);
+    it('upserts when saving a training for an existing date', async () => {
+      const { saveTraining, getTraining } = await import('./training.service');
+      const updated: Training = { ...mockTraining, steps: { workout: ['Warrior I'] } };
+      await saveTraining(mockTraining);
+      await saveTraining(updated);
+      const result = await getTraining('2024-03-15');
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value?.steps).toEqual({ workout: ['Warrior I'] });
+      }
+    });
+
+    it('returns an error result when IndexedDB is unavailable', async () => {
+      vi.doMock('@/lib/db', () => ({
+        getDb: () => Promise.reject(new Error('IDB unavailable')),
+      }));
+      const { saveTraining } = await import('./training.service');
+      const result = await saveTraining(mockTraining);
+      expect(result.ok).toBe(false);
     });
   });
 
-  describe('getTrainings', () => {
-    it('returns the training matching the date', () => {
-      saveTraining(mockTraining);
-      const result = getTrainings('2024-03-15');
-      expect(result).toEqual(mockTraining);
+  describe('getTraining', () => {
+    it('returns the training matching the given date', async () => {
+      const { saveTraining, getTraining } = await import('./training.service');
+      await saveTraining(mockTraining);
+      const result = await getTraining('2024-03-15');
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value).toEqual(mockTraining);
+      }
     });
 
-    it('returns undefined when no training found for the date', () => {
-      saveTraining(mockTraining);
-      expect(getTrainings('1999-01-01')).toBeUndefined();
+    it('returns undefined when no training exists for the date', async () => {
+      const { getTraining } = await import('./training.service');
+      const result = await getTraining('1999-01-01');
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value).toBeUndefined();
+      }
     });
 
-    it('returns undefined when localStorage is empty', () => {
-      expect(getTrainings('2024-03-15')).toBeUndefined();
+    it('returns an error result when IndexedDB is unavailable', async () => {
+      vi.doMock('@/lib/db', () => ({
+        getDb: () => Promise.reject(new Error('IDB unavailable')),
+      }));
+      const { getTraining } = await import('./training.service');
+      const result = await getTraining('2024-03-15');
+      expect(result.ok).toBe(false);
     });
   });
 });

--- a/src/services/training.service.ts
+++ b/src/services/training.service.ts
@@ -1,20 +1,37 @@
-import { Training } from '@/models/training.model';
+import type { Training } from '@/models/training.model';
+import { getDb } from '@/lib/db';
 
-export const saveTraining = (training: Training): void  => {
-  localSaveTraining(training);
-}
+type Result<T, E extends Error = Error> = { ok: true; value: T } | { ok: false; error: E };
 
-export const getTrainings = (date: string): Training | undefined => {
-  const allLocalTrainings = localGetTrainings();
-  return allLocalTrainings.find((training) => training.date === date);
-}
+export const migrateFromLocalStorage = async (): Promise<void> => {
+  const raw = localStorage.getItem('trainings');
+  if (!raw) return;
+  try {
+    const records: Training[] = JSON.parse(raw);
+    const db = await getDb();
+    await Promise.all(records.map((r) => db.put('trainings', r)));
+    localStorage.removeItem('trainings');
+  } catch {
+    // noop
+  }
+};
 
-const localSaveTraining = (training: Training): void => {
-  const trainings = JSON.parse(localStorage.getItem('trainings') || '[]');
-  trainings.push(training);
-  localStorage.setItem('trainings', JSON.stringify(trainings));
-}
+export const saveTraining = async (training: Training): Promise<Result<void>> => {
+  try {
+    const db = await getDb();
+    await db.put('trainings', training);
+    return { ok: true, value: undefined };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e : new Error(String(e)) };
+  }
+};
 
-const localGetTrainings = (): Training[] => {
-  return JSON.parse(localStorage.getItem('trainings') || '[]');
-}
+export const getTraining = async (date: string): Promise<Result<Training | undefined>> => {
+  try {
+    const db = await getDb();
+    const training = await db.get('trainings', date);
+    return { ok: true, value: training };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e : new Error(String(e)) };
+  }
+};

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     setupFiles: ['./src/test/setup.ts'],
+    exclude: ['**/node_modules/**', '**/.claude/worktrees/**'],
   },
   resolve: {
     alias: { '@': path.resolve(__dirname, './src') },


### PR DESCRIPTION
## Summary

- Migrates training data persistence from localStorage to IndexedDB (`src/lib/db.ts`)
- Adds OpenSpec `config.yaml` with project context and artifact rules
- Archives the IndexedDB migration change in `openspec/changes/archive/`
- Adds OPSX slash commands and skills for the experimental OpenSpec workflow
- Excludes `.claude/worktrees` from Vitest test discovery
- Comments out auto-deploy to GitHub Pages workflow

## Commits

- `chore: populate OpenSpec config with project context and artifact rules`
- `feat: migrate training storage from localStorage to IndexedDB`
- `chore: exclude .claude/worktrees from Vitest test discovery`
- `chore: add OpenSpec config, change artifacts, and archive for indexeddb migration`
- `feat: add OPSX commands for managing changes in the experimental workflow`
- `Comment out auto deploy to gh pages`

## Test plan

- [ ] Verify existing training data loads correctly after IndexedDB migration
- [ ] Create a new training and confirm it persists across page reloads
- [ ] Confirm `npm test` passes
- [ ] Confirm `npm run lint` passes with zero warnings
- [ ] Confirm `npx tsc --noEmit` passes with zero errors
- [ ] Check that `openspec/config.yaml` is present and contains project context

🤖 Generated with [Claude Code](https://claude.com/claude-code)